### PR TITLE
I've added comprehensive unit and integration tests for the recently …

### DIFF
--- a/surfsense_backend/app/routes/test_search_source_connectors_routes.py
+++ b/surfsense_backend/app/routes/test_search_source_connectors_routes.py
@@ -1,0 +1,297 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock, AsyncMock
+from fastapi import BackgroundTasks, HTTPException
+
+from app.main import app # Assuming your FastAPI app instance is here
+from app.db import User, SearchSourceConnector, SearchSourceConnectorType, SearchSpace
+from app.schemas.search_source_connector import SearchSourceConnectorRead # For response validation if needed
+from app.connectors.slack_history import SlackHistory # To mock its methods
+from slack_sdk.errors import SlackApiError
+
+# --- Fixtures ---
+
+@pytest.fixture
+def mock_user():
+    user = User(id="test_user_1", email="test@example.com", hashed_password="hashedpassword", is_active=True, is_superuser=False)
+    return user
+
+@pytest.fixture
+def mock_db_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.get = AsyncMock() # For individual record fetching by ID
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+@pytest.fixture
+def mock_background_tasks():
+    tasks = MagicMock(spec=BackgroundTasks)
+    tasks.add_task = MagicMock()
+    return tasks
+
+@pytest.fixture
+def test_client(mock_user, mock_db_session, mock_background_tasks):
+    # Override dependencies
+    app.dependency_overrides[current_active_user_dep] = lambda: mock_user
+    app.dependency_overrides[get_async_session_dep] = lambda: mock_db_session
+    # To inject BackgroundTasks, it's usually passed directly to the route function.
+    # So, we'll mock it where it's used, or ensure it's injectable.
+    # For testing, the TestClient can handle BackgroundTasks if routes are defined correctly.
+    # If BackgroundTasks is a dependency, it can be overridden too.
+    # For this test, we'll often patch where BackgroundTasks.add_task is called.
+    return TestClient(app)
+
+# --- Helper to get current_active_user dependency ---
+# This is needed because current_active_user is likely defined in app.users
+# and we need to provide the correct path for overriding.
+# Assuming it's from app.users:
+from app.users import current_active_user as current_active_user_dep
+from app.db import get_async_session as get_async_session_dep
+
+
+# --- Base Slack Connector Data ---
+@pytest.fixture
+def base_slack_connector_db():
+    return SearchSourceConnector(
+        id=1,
+        user_id="test_user_1",
+        name="Test Slack",
+        connector_type=SearchSourceConnectorType.SLACK_CONNECTOR,
+        is_indexable=True,
+        config={"SLACK_BOT_TOKEN": "xoxb-valid-token"},
+        last_indexed_at=None
+    )
+
+@pytest.fixture
+def mock_search_space_db():
+    return SearchSpace(id=1, name="Test Space", user_id="test_user_1")
+
+
+# --- Test Classes ---
+
+class TestDiscoverSlackChannels:
+
+    @patch('app.routes.search_source_connectors_routes.SlackHistory')
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_discover_channels_success(self, mock_check_ownership, MockSlackHistory, test_client, mock_db_session, base_slack_connector_db):
+        mock_check_ownership.return_value = base_slack_connector_db
+        mock_db_session.get.return_value = base_slack_connector_db # For direct session.get calls
+
+        mock_slack_instance = MockSlackHistory.return_value
+        mock_slack_instance.get_all_channels.return_value = [
+            {"id": "C1", "name": "General", "is_private": False, "is_member": True},
+            {"id": "C2", "name": "Private", "is_private": True, "is_member": True},
+            {"id": "C3", "name": "Public-NotMember", "is_private": False, "is_member": False},
+        ]
+
+        response = test_client.get("/api/v1/slack/1/discover-channels")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["channels"]) == 2 # C3 should be filtered out
+        assert data["channels"][0]["id"] == "C1"
+        assert data["channels"][1]["id"] == "C2"
+        MockSlackHistory.assert_called_once_with(token="xoxb-valid-token")
+        mock_slack_instance.get_all_channels.assert_called_once_with(include_private=True)
+
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_discover_channels_connector_not_found(self, mock_check_ownership, test_client):
+        mock_check_ownership.side_effect = HTTPException(status_code=404, detail="Connector not found")
+        # Or, if session.get is used directly before check_ownership in the route:
+        # mock_db_session.get.return_value = None
+        # For this test, assuming check_ownership is the primary guard or session.get is part of it.
+
+        response = test_client.get("/api/v1/slack/999/discover-channels")
+        assert response.status_code == 404
+
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_discover_channels_not_slack_connector(self, mock_check_ownership, test_client, base_slack_connector_db):
+        base_slack_connector_db.connector_type = SearchSourceConnectorType.NOTION_CONNECTOR
+        mock_check_ownership.return_value = base_slack_connector_db
+        # mock_db_session.get.return_value = base_slack_connector_db
+
+        response = test_client.get("/api/v1/slack/1/discover-channels")
+        assert response.status_code == 400
+        assert "Connector is not a Slack connector" in response.json()["detail"]
+
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_discover_channels_token_not_configured(self, mock_check_ownership, test_client, base_slack_connector_db):
+        base_slack_connector_db.config = {} # No token
+        mock_check_ownership.return_value = base_slack_connector_db
+        # mock_db_session.get.return_value = base_slack_connector_db
+
+        response = test_client.get("/api/v1/slack/1/discover-channels")
+        assert response.status_code == 400
+        assert "Slack token not configured" in response.json()["detail"]
+
+    @patch('app.routes.search_source_connectors_routes.SlackHistory')
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_discover_channels_slack_api_error(self, mock_check_ownership, MockSlackHistory, test_client, base_slack_connector_db):
+        mock_check_ownership.return_value = base_slack_connector_db
+        # mock_db_session.get.return_value = base_slack_connector_db
+        
+        mock_slack_instance = MockSlackHistory.return_value
+        # Simulate SlackApiError with a mock response object that has a 'data' attribute
+        mock_error_response = MagicMock()
+        mock_error_response.data = {"error": "test_slack_api_error"}
+        mock_slack_instance.get_all_channels.side_effect = SlackApiError("Slack API failed", mock_error_response)
+
+        response = test_client.get("/api/v1/slack/1/discover-channels")
+        assert response.status_code == 500 # Based on current route error handling
+        assert "Slack API error: test_slack_api_error" in response.json()["detail"]
+
+    @patch('app.routes.search_source_connectors_routes.SlackHistory')
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_discover_channels_value_error(self, mock_check_ownership, MockSlackHistory, test_client, base_slack_connector_db):
+        mock_check_ownership.return_value = base_slack_connector_db
+        # mock_db_session.get.return_value = base_slack_connector_db
+        MockSlackHistory.side_effect = ValueError("Invalid token format") # Error on SlackHistory init
+
+        response = test_client.get("/api/v1/slack/1/discover-channels")
+        assert response.status_code == 400
+        assert "Invalid token format" in response.json()["detail"]
+
+
+class TestReindexSlackChannels:
+
+    @patch('app.routes.search_source_connectors_routes.run_slack_indexing_with_new_session', new_callable=AsyncMock)
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_reindex_channels_success_defaults(self, mock_check_ownership, mock_run_indexing, test_client, mock_db_session, base_slack_connector_db, mock_search_space_db, mock_background_tasks):
+        mock_check_ownership.return_value = base_slack_connector_db
+        mock_db_session.get.return_value = base_slack_connector_db
+        # Mock the search space query within the endpoint
+        mock_db_session.execute.return_value.scalars.return_value.first.return_value = mock_search_space_db
+        
+        # Override BackgroundTasks for this specific test or ensure it's injected globally
+        with patch('fastapi.BackgroundTasks', return_value=mock_background_tasks) as MockedBGTasks:
+             # Re-apply dependency override if TestClient re-initializes app without it for BG tasks
+            app.dependency_overrides[BackgroundTasks] = lambda: mock_background_tasks
+
+            response = test_client.post("/api/v1/slack/1/reindex-channels", json={"channel_ids": ["C1", "C2"]})
+
+            assert response.status_code == 202
+            assert response.json()["message"] == "Re-indexing task for specific channels has been scheduled."
+            
+            mock_background_tasks.add_task.assert_called_once_with(
+                mock_run_indexing, # Direct reference to the mocked task runner
+                connector_id=1,
+                search_space_id=mock_search_space_db.id,
+                target_channel_ids=["C1", "C2"],
+                force_reindex_all_messages=False, # Default
+                reindex_start_date_str=None,      # Default
+                reindex_latest_date_str=None       # Default
+            )
+            # Clean up dependency override if it was local to this test
+            if BackgroundTasks in app.dependency_overrides:
+                 del app.dependency_overrides[BackgroundTasks]
+
+
+    @patch('app.routes.search_source_connectors_routes.run_slack_indexing_with_new_session', new_callable=AsyncMock)
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_reindex_channels_success_with_optional_params(self, mock_check_ownership, mock_run_indexing, test_client, mock_db_session, base_slack_connector_db, mock_search_space_db, mock_background_tasks):
+        mock_check_ownership.return_value = base_slack_connector_db
+        mock_db_session.get.return_value = base_slack_connector_db
+        mock_db_session.execute.return_value.scalars.return_value.first.return_value = mock_search_space_db
+
+        with patch('fastapi.BackgroundTasks', return_value=mock_background_tasks):
+            app.dependency_overrides[BackgroundTasks] = lambda: mock_background_tasks
+            payload = {
+                "channel_ids": ["C1"],
+                "force_reindex_all_messages": True,
+                "reindex_start_date": "2023-01-01",
+                "reindex_latest_date": "2023-01-31"
+            }
+            response = test_client.post("/api/v1/slack/1/reindex-channels", json=payload)
+
+            assert response.status_code == 202
+            mock_background_tasks.add_task.assert_called_once_with(
+                mock_run_indexing,
+                connector_id=1,
+                search_space_id=mock_search_space_db.id,
+                target_channel_ids=["C1"],
+                force_reindex_all_messages=True,
+                reindex_start_date_str="2023-01-01",
+                reindex_latest_date_str="2023-01-31"
+            )
+            if BackgroundTasks in app.dependency_overrides:
+                 del app.dependency_overrides[BackgroundTasks]
+
+    # Error cases for reindex-channels (similar structure to discover-channels errors)
+    # Connector not found, not Slack, token missing, no channel_ids
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_reindex_channels_no_channel_ids(self, mock_check_ownership, test_client, mock_db_session, base_slack_connector_db):
+        mock_check_ownership.return_value = base_slack_connector_db
+        mock_db_session.get.return_value = base_slack_connector_db
+        
+        response = test_client.post("/api/v1/slack/1/reindex-channels", json={"channel_ids": []}) # Empty list
+        assert response.status_code == 400 # Or 422 depending on Pydantic validation
+        assert "No channel_ids provided" in response.json()["detail"]
+
+
+class TestIndexConnectorContentSlack:
+
+    @patch('app.routes.search_source_connectors_routes.run_slack_indexing_with_new_session', new_callable=AsyncMock)
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_index_slack_connector_default(self, mock_check_ownership, mock_run_indexing, test_client, mock_db_session, base_slack_connector_db, mock_search_space_db, mock_background_tasks):
+        # Mock check_ownership for connector and search_space
+        mock_check_ownership.side_effect = [base_slack_connector_db, mock_search_space_db]
+        
+        with patch('fastapi.BackgroundTasks', return_value=mock_background_tasks):
+            app.dependency_overrides[BackgroundTasks] = lambda: mock_background_tasks
+            response = test_client.post("/api/v1/search-source-connectors/1/index?search_space_id=1")
+
+            assert response.status_code == 200 # The route itself returns 200, task is background
+            assert "Slack indexing started" in response.json()["message"]
+            
+            mock_background_tasks.add_task.assert_called_once_with(
+                mock_run_indexing,
+                1, # connector_id
+                1, # search_space_id
+                target_channel_ids=None, # From default in run_slack_indexing_with_new_session
+                force_reindex_all_messages=False, # Default for this endpoint
+                reindex_start_date_str=None,
+                reindex_latest_date_str=None
+            )
+            if BackgroundTasks in app.dependency_overrides:
+                 del app.dependency_overrides[BackgroundTasks]
+
+    @patch('app.routes.search_source_connectors_routes.run_slack_indexing_with_new_session', new_callable=AsyncMock)
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_index_slack_connector_force_full_reindex(self, mock_check_ownership, mock_run_indexing, test_client, mock_db_session, base_slack_connector_db, mock_search_space_db, mock_background_tasks):
+        mock_check_ownership.side_effect = [base_slack_connector_db, mock_search_space_db]
+
+        with patch('fastapi.BackgroundTasks', return_value=mock_background_tasks):
+            app.dependency_overrides[BackgroundTasks] = lambda: mock_background_tasks
+            response = test_client.post("/api/v1/search-source-connectors/1/index?search_space_id=1&force_full_reindex=true")
+
+            assert response.status_code == 200
+            assert "Full re-index initiated" in response.json()["message"]
+            
+            mock_background_tasks.add_task.assert_called_once_with(
+                mock_run_indexing,
+                1, 
+                1, 
+                target_channel_ids=None,
+                force_reindex_all_messages=True, # Key check for this test
+                reindex_start_date_str=None,
+                reindex_latest_date_str=None
+            )
+            if BackgroundTasks in app.dependency_overrides:
+                 del app.dependency_overrides[BackgroundTasks]
+
+    @patch('app.routes.search_source_connectors_routes.check_ownership', new_callable=AsyncMock)
+    async def test_index_connector_not_supported_type(self, mock_check_ownership, test_client, base_slack_connector_db, mock_search_space_db):
+        base_slack_connector_db.connector_type = "UNSUPPORTED_TYPE" # Simulate an unsupported type
+        mock_check_ownership.side_effect = [base_slack_connector_db, mock_search_space_db]
+
+        response = test_client.post("/api/v1/search-source-connectors/1/index?search_space_id=1")
+        assert response.status_code == 400
+        assert "Indexing not supported for connector type: UNSUPPORTED_TYPE" in response.json()["detail"]
+
+# It's important to clear dependency_overrides after tests if they are not scoped to TestClient instance
+# However, pytest fixtures usually handle setup/teardown per test.
+# If overrides are global to 'app', they might need explicit cleanup in a teardown fixture if not using TestClient's context management fully.
+# For TestClient(app), it usually handles this.

--- a/surfsense_backend/app/tasks/test_connectors_indexing_tasks.py
+++ b/surfsense_backend/app/tasks/test_connectors_indexing_tasks.py
@@ -1,0 +1,427 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+from datetime import datetime, timedelta, timezone
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.tasks.connectors_indexing_tasks import index_slack_messages
+from app.db import SearchSourceConnector, SearchSourceConnectorType, Document, DocumentType, Chunk
+from app.schemas.search_source_connector import SearchSourceConnectorCreate # For creating test connector data
+from app.connectors.slack_history import SlackHistory # To mock its methods
+
+# Mock global config object if it's accessed directly
+# If it's passed around, then mock where it's used/passed.
+# For this example, assuming app.config.config is used.
+@pytest.fixture(autouse=True)
+def mock_app_config():
+    mock_llm = MagicMock()
+    mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="Test Summary"))
+
+    mock_embedding_model = MagicMock()
+    mock_embedding_model.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+    
+    mock_chunker = MagicMock()
+    # Simulate chunker returning list of objects with a 'text' attribute
+    mock_chunker.chunk = MagicMock(return_value=[MagicMock(text="chunk1"), MagicMock(text="chunk2")])
+
+    with patch('app.config.config.long_context_llm_instance', mock_llm), \
+         patch('app.config.config.embedding_model_instance', mock_embedding_model), \
+         patch('app.config.config.chunker_instance', mock_chunker), \
+         patch('app.config.config.SUMMARY_PROMPT_TEMPLATE', MagicMock()): # Assuming this is a simple object
+        yield
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.scalars = MagicMock(return_value=MagicMock(first=MagicMock(return_value=None), all=MagicMock(return_value=[])))
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.add = MagicMock()
+    session.refresh = AsyncMock()
+    return session
+
+@pytest.fixture
+def base_slack_connector():
+    return SearchSourceConnector(
+        id=1,
+        user_id="test_user_1",
+        search_space_id=1,
+        name="Test Slack Connector",
+        connector_type=SearchSourceConnectorType.SLACK_CONNECTOR,
+        is_indexable=True,
+        config={
+            "SLACK_BOT_TOKEN": "xoxb-dummy-token",
+            "slack_initial_indexing_days": 30,
+            "slack_initial_max_messages_per_channel": 100,
+            "slack_max_messages_per_channel_periodic": 50,
+            "slack_membership_filter_type": "all_member_channels",
+            "slack_selected_channel_ids": [],
+            "slack_periodic_indexing_enabled": True, # New field from previous task
+            "slack_periodic_indexing_frequency": "daily" # New field
+        },
+        last_indexed_at=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+@pytest.fixture
+def mock_slack_history_instance():
+    instance = AsyncMock(spec=SlackHistory)
+    instance.get_all_channels = AsyncMock(return_value=[])
+    instance.get_conversation_history = AsyncMock(return_value=[])
+    # format_message should return a dict, not an AsyncMock
+    instance.format_message = MagicMock(return_value={
+        "user_id": "U123", "text": "Formatted message", "datetime": "2023-01-01 10:00:00 UTC"
+    })
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_connector_not_found(mock_session):
+    mock_session.execute.return_value.scalars.return_value.first.return_value = None
+    count, error = await index_slack_messages(mock_session, 999, 1)
+    assert count == 0
+    assert "Connector with ID 999 not found" in error
+
+@pytest.mark.asyncio
+async def test_connector_not_slack_type(mock_session, base_slack_connector):
+    base_slack_connector.connector_type = SearchSourceConnectorType.NOTION_CONNECTOR
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    count, error = await index_slack_messages(mock_session, 1, 1)
+    assert count == 0
+    assert "is not a Slack connector" in error
+
+@pytest.mark.asyncio
+async def test_slack_token_missing(mock_session, base_slack_connector):
+    base_slack_connector.config = {} # No token
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    count, error = await index_slack_messages(mock_session, 1, 1)
+    assert count == 0
+    assert "Slack token not found" in error
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_no_channels_returned_from_api(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels = AsyncMock(return_value=[])
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    
+    count, error = await index_slack_messages(mock_session, 1, 1)
+    assert count == 0
+    assert error == "No channels to index after filtering." # This is the specific message when no channels are left
+    # Verify last_indexed_at is updated because the task "ran" successfully even if no channels
+    assert base_slack_connector.last_indexed_at is not None 
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_all_member_channels_filter(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.return_value = [
+        {"id": "C1", "name": "Channel1", "is_member": True, "is_private": False},
+        {"id": "C2", "name": "Channel2", "is_member": True, "is_private": False}, # Bot is member
+    ]
+    mock_slack_history_instance.get_conversation_history.return_value = [
+        {"ts": "1", "user": "U1", "text": "msg1"},
+    ]
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    base_slack_connector.config["slack_membership_filter_type"] = "all_member_channels"
+
+    count, _ = await index_slack_messages(mock_session, 1, 1)
+    assert count == 2 # Two documents created, one for each channel
+    assert mock_slack_history_instance.get_conversation_history.call_count == 2
+    mock_slack_history_instance.get_conversation_history.assert_any_call(channel_id="C1", limit=100, oldest=mock_slack_history_instance.convert_date_to_timestamp.return_value, latest=mock_slack_history_instance.convert_date_to_timestamp.return_value)
+    mock_slack_history_instance.get_conversation_history.assert_any_call(channel_id="C2", limit=100, oldest=mock_slack_history_instance.convert_date_to_timestamp.return_value, latest=mock_slack_history_instance.convert_date_to_timestamp.return_value)
+
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_selected_member_channels_filter(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.return_value = [
+        {"id": "C1", "name": "Channel1", "is_member": True, "is_private": False},
+        {"id": "C2", "name": "Channel2", "is_member": True, "is_private": False},
+        {"id": "C3", "name": "Channel3", "is_member": True, "is_private": False},
+    ]
+    mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1", "user": "U1", "text": "msg1"}]
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    base_slack_connector.config["slack_membership_filter_type"] = "selected_member_channels"
+    base_slack_connector.config["slack_selected_channel_ids"] = ["C1", "C3"]
+
+    count, _ = await index_slack_messages(mock_session, 1, 1)
+    assert count == 2
+    assert mock_slack_history_instance.get_conversation_history.call_count == 2
+    mock_slack_history_instance.get_conversation_history.assert_any_call(channel_id="C1", limit=100, oldest=mock_slack_history_instance.convert_date_to_timestamp.return_value, latest=mock_slack_history_instance.convert_date_to_timestamp.return_value)
+    mock_slack_history_instance.get_conversation_history.assert_any_call(channel_id="C3", limit=100, oldest=mock_slack_history_instance.convert_date_to_timestamp.return_value, latest=mock_slack_history_instance.convert_date_to_timestamp.return_value)
+    # C2 should not have been called
+
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_target_channel_ids_interaction(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.return_value = [
+        {"id": "C1", "name": "Channel1", "is_member": True, "is_private": False},
+        {"id": "C2", "name": "Channel2", "is_member": True, "is_private": False}, # Configured but not targeted
+        {"id": "C3", "name": "Channel3", "is_member": True, "is_private": False}, # Targeted
+    ]
+    mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1", "user": "U1", "text": "msg1"}]
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    base_slack_connector.config["slack_membership_filter_type"] = "all_member_channels" # All are initially valid
+
+    count, _ = await index_slack_messages(mock_session, 1, 1, target_channel_ids=["C1", "C3"])
+    assert count == 2 # Only C1 and C3
+    mock_slack_history_instance.get_conversation_history.assert_any_call(channel_id="C1", limit=base_slack_connector.config["slack_max_messages_per_channel_periodic"], oldest=mock_slack_history_instance.convert_date_to_timestamp.return_value, latest=mock_slack_history_instance.convert_date_to_timestamp.return_value)
+    mock_slack_history_instance.get_conversation_history.assert_any_call(channel_id="C3", limit=base_slack_connector.config["slack_max_messages_per_channel_periodic"], oldest=mock_slack_history_instance.convert_date_to_timestamp.return_value, latest=mock_slack_history_instance.convert_date_to_timestamp.return_value)
+    # Ensure C2 was not called for history
+    calls = mock_slack_history_instance.get_conversation_history.call_args_list
+    for c in calls:
+        assert c.kwargs['channel_id'] != "C2"
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_initial_indexing_days_logic(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    base_slack_connector.last_indexed_at = None # Ensure initial run
+    base_slack_connector.config["slack_initial_indexing_days"] = 7
+    
+    # Mock convert_date_to_timestamp to check its input
+    mock_converter = MagicMock()
+    # Make it return a fixed value so we can check the call to get_conversation_history
+    fixed_ts = str(int((datetime.now(timezone.utc) - timedelta(days=7)).timestamp()))
+    mock_converter.return_value = fixed_ts 
+    # Patch the static method on the class, not the instance
+    with patch.object(SlackHistory, 'convert_date_to_timestamp', mock_converter):
+        mock_slack_history_instance.get_all_channels.return_value = [{"id": "C1", "name": "Chan1", "is_member": True}]
+        mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1"}]
+        MockSlackHistory.return_value = mock_slack_history_instance
+        mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+
+        await index_slack_messages(mock_session, 1, 1)
+        
+        # Check if convert_date_to_timestamp was called correctly for the start date
+        # It's called internally for both oldest and latest. We are interested in the 'oldest' logic.
+        # The actual call to SlackHistory.convert_date_to_timestamp for 'oldest' happens inside index_slack_messages.
+        # We can assert that get_conversation_history was called with the 'fixed_ts'
+        
+        latest_ts_for_call = str(int((datetime.now(timezone.utc) + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()))
+
+        mock_slack_history_instance.get_conversation_history.assert_called_once_with(
+            channel_id="C1",
+            limit=base_slack_connector.config["slack_initial_max_messages_per_channel"],
+            oldest=fixed_ts, # This is the key check
+            latest=latest_ts_for_call
+        )
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_initial_indexing_all_time(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    base_slack_connector.last_indexed_at = None
+    base_slack_connector.config["slack_initial_indexing_days"] = -1
+    mock_slack_history_instance.get_all_channels.return_value = [{"id": "C1", "name": "Chan1", "is_member": True}]
+    mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1"}]
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+
+    await index_slack_messages(mock_session, 1, 1)
+    latest_ts_for_call = str(int((datetime.now(timezone.utc) + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()))
+    mock_slack_history_instance.get_conversation_history.assert_called_once_with(
+        channel_id="C1",
+        limit=base_slack_connector.config["slack_initial_max_messages_per_channel"],
+        oldest="0", # All time
+        latest=latest_ts_for_call
+    )
+
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_periodic_indexing_logic(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    last_indexed_time = datetime.now(timezone.utc) - timedelta(days=5)
+    base_slack_connector.last_indexed_at = last_indexed_time
+    
+    mock_slack_history_instance.get_all_channels.return_value = [{"id": "C1", "name": "Chan1", "is_member": True}]
+    mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1"}]
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+
+    await index_slack_messages(mock_session, 1, 1)
+    
+    expected_oldest_ts = str(int(last_indexed_time.timestamp()))
+    latest_ts_for_call = str(int((datetime.now(timezone.utc) + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()))
+
+    mock_slack_history_instance.get_conversation_history.assert_called_once_with(
+        channel_id="C1",
+        limit=base_slack_connector.config["slack_max_messages_per_channel_periodic"],
+        oldest=expected_oldest_ts,
+        latest=latest_ts_for_call
+    )
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_reindex_force_all_with_dates(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.return_value = [{"id": "C1", "name": "Chan1", "is_member": True}]
+    mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1"}]
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+
+    start_date_str = "2023-03-01"
+    latest_date_str = "2023-03-10"
+    expected_oldest = SlackHistory.convert_date_to_timestamp(start_date_str)
+    expected_latest = SlackHistory.convert_date_to_timestamp(latest_date_str, is_latest=True)
+
+    await index_slack_messages(mock_session, 1, 1, 
+                               target_channel_ids=["C1"], 
+                               force_reindex_all_messages=True, 
+                               reindex_start_date_str=start_date_str, 
+                               reindex_latest_date_str=latest_date_str)
+    
+    mock_slack_history_instance.get_conversation_history.assert_called_once_with(
+        channel_id="C1",
+        limit=base_slack_connector.config["slack_initial_max_messages_per_channel"], # Uses initial limit
+        oldest=expected_oldest,
+        latest=expected_latest
+    )
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_document_creation(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.return_value = [{"id": "C1", "name": "TestChannel", "is_member": True}]
+    mock_slack_history_instance.get_conversation_history.return_value = [
+        {"ts": "1", "user": "U1", "text": "Hello"},
+        {"ts": "2", "user": "U2", "text": "World", "subtype": "bot_message"}, # Should be skipped
+    ]
+    # Configure format_message to return what's needed by the task
+    mock_slack_history_instance.format_message.side_effect = lambda msg, include_user_info=False: {
+        "user_id": msg["user"], "text": msg["text"], "datetime": "time", "subtype": msg.get("subtype")
+    }
+
+    MockSlackHistory.return_value = mock_slack_history_instance
+    # Simulate no existing document for this channel
+    mock_session.execute.return_value.scalars.return_value.all.return_value = [] 
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector # For connector fetch
+
+    count, _ = await index_slack_messages(mock_session, 1, 1)
+    assert count == 1
+    
+    # Check Document creation (session.add was called with a Document instance)
+    added_object = mock_session.add.call_args[0][0]
+    assert isinstance(added_object, Document)
+    assert added_object.title == "Slack - TestChannel"
+    assert added_object.document_type == DocumentType.SLACK_CONNECTOR
+    assert added_object.document_metadata["channel_id"] == "C1"
+    assert added_object.document_metadata["message_count"] == 1 # Only one valid message
+    assert added_object.content == "Test Summary" # From mock_app_config
+    assert len(added_object.chunks) == 2 # From mock_app_config chunker
+
+    # Check that bot message was skipped via format_message calls
+    format_calls = mock_slack_history_instance.format_message.call_args_list
+    assert len(format_calls) == 1 # Only called for the non-bot message
+    assert format_calls[0].args[0]['text'] == "Hello"
+    
+    assert mock_session.commit.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_document_update(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.return_value = [{"id": "C1", "name": "TestChannel", "is_member": True}]
+    mock_slack_history_instance.get_conversation_history.return_value = [{"ts": "1", "user": "U1", "text": "Updated Content"}]
+    mock_slack_history_instance.format_message.return_value = {"user_id": "U1", "text": "Updated Content", "datetime":"time"}
+    MockSlackHistory.return_value = mock_slack_history_instance
+    
+    existing_doc = Document(id=101, search_space_id=1, title="Old Title", document_type=DocumentType.SLACK_CONNECTOR, document_metadata={"channel_id": "C1"})
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+    # Simulate existing document for this channel_id
+    mock_session.execute.return_value.scalars.return_value.all.return_value = [existing_doc] 
+
+    count, _ = await index_slack_messages(mock_session, 1, 1)
+    assert count == 1 # 0 new, 1 updated
+    
+    assert existing_doc.content == "Test Summary" # Updated content from summary
+    assert existing_doc.document_metadata["message_count"] == 1
+    # Check that session.delete was called for old chunks (implicitly via relationship or explicit call)
+    # This depends on ORM setup or if task explicitly deletes.
+    # For this test, we assume the task handles deleting old chunks if needed.
+    # The provided task code does execute a delete statement for chunks.
+    delete_chunk_call = None
+    for call_item in mock_session.execute.call_args_list:
+        if "DELETE" in str(call_item.args[0]): # Check if a DELETE statement was executed
+            delete_chunk_call = call_item
+            break
+    assert delete_chunk_call is not None 
+    
+    # Verify new chunks are added
+    num_new_chunks_added = 0
+    for call_item in mock_session.add.call_args_list:
+        if isinstance(call_item.args[0], Chunk):
+            num_new_chunks_added +=1
+            assert call_item.args[0].document_id == existing_doc.id # Associated with existing doc
+    assert num_new_chunks_added == 2 # From mock_app_config chunker
+
+    assert mock_session.commit.call_count == 1
+
+@pytest.mark.asyncio
+async def test_last_indexed_at_update_logic(mock_session, base_slack_connector):
+    # Scenario 1: update_last_indexed = True, documents processed
+    mock_slack_history_instance_s1 = MagicMock(spec=SlackHistory)
+    mock_slack_history_instance_s1.get_all_channels = AsyncMock(return_value=[{"id": "C1", "name": "Chan1", "is_member": True}])
+    mock_slack_history_instance_s1.get_conversation_history = AsyncMock(return_value=[{"ts": "1", "user": "U1", "text": "msg"}])
+    mock_slack_history_instance_s1.format_message = MagicMock(return_value={"user_id":"U1", "text":"msg", "datetime":"t"})
+
+    with patch('app.tasks.connectors_indexing_tasks.SlackHistory', return_value=mock_slack_history_instance_s1):
+        mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+        base_slack_connector.last_indexed_at = None # Reset for this test part
+        await index_slack_messages(mock_session, 1, 1, update_last_indexed=True)
+        assert base_slack_connector.last_indexed_at is not None
+        original_last_indexed_at = base_slack_connector.last_indexed_at
+
+    # Scenario 2: update_last_indexed = False
+    mock_slack_history_instance_s2 = MagicMock(spec=SlackHistory)
+    mock_slack_history_instance_s2.get_all_channels = AsyncMock(return_value=[{"id": "C1", "name": "Chan1", "is_member": True}])
+    mock_slack_history_instance_s2.get_conversation_history = AsyncMock(return_value=[{"ts": "1", "user": "U1", "text": "msg"}])
+    mock_slack_history_instance_s2.format_message = MagicMock(return_value={"user_id":"U1", "text":"msg", "datetime":"t"})
+    
+    with patch('app.tasks.connectors_indexing_tasks.SlackHistory', return_value=mock_slack_history_instance_s2):
+        mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+        # last_indexed_at should remain as it was from scenario 1
+        await index_slack_messages(mock_session, 1, 1, update_last_indexed=False)
+        assert base_slack_connector.last_indexed_at == original_last_indexed_at
+
+
+@pytest.mark.asyncio
+@patch('app.tasks.connectors_indexing_tasks.SlackHistory')
+async def test_error_get_all_channels_exception(MockSlackHistory, mock_session, base_slack_connector, mock_slack_history_instance):
+    mock_slack_history_instance.get_all_channels.side_effect = Exception("Failed to get channels")
+    MockSlackHistory.return_value = mock_slack_history_instance
+    mock_session.execute.return_value.scalars.return_value.first.return_value = base_slack_connector
+
+    count, error = await index_slack_messages(mock_session, 1, 1)
+    assert count == 0
+    assert "Failed to get Slack channels: Failed to get channels" in error
+    assert mock_session.rollback.call_count == 1 # Should rollback on general exception
+
+@pytest.mark.asyncio
+async def test_db_error_on_commit(mock_session, base_slack_connector):
+    # This test needs to allow the initial connector fetch to succeed, then fail on commit
+    mock_connector_fetch_result = MagicMock()
+    mock_connector_fetch_result.scalars.return_value.first.return_value = base_slack_connector
+    
+    mock_docs_fetch_result = MagicMock()
+    mock_docs_fetch_result.scalars.return_value.all.return_value = [] # No existing docs
+
+    # Configure side_effect for session.execute
+    mock_session.execute.side_effect = [
+        mock_connector_fetch_result, # First call for getting connector
+        mock_docs_fetch_result       # Second call for getting existing_docs
+    ]
+    
+    mock_session.commit.side_effect = SQLAlchemyError("DB Commit Failed")
+
+    mock_slack_history_instance_db_error = MagicMock(spec=SlackHistory)
+    mock_slack_history_instance_db_error.get_all_channels = AsyncMock(return_value=[{"id": "C1", "name": "Chan1", "is_member": True}])
+    mock_slack_history_instance_db_error.get_conversation_history = AsyncMock(return_value=[{"ts": "1", "user":"U1", "text":"msg"}])
+    mock_slack_history_instance_db_error.format_message = MagicMock(return_value={"user_id":"U1", "text":"msg", "datetime":"t"})
+
+    with patch('app.tasks.connectors_indexing_tasks.SlackHistory', return_value=mock_slack_history_instance_db_error):
+        count, error = await index_slack_messages(mock_session, 1, 1)
+        assert count == 0
+        assert "Database error: DB Commit Failed" in error
+        assert mock_session.rollback.call_count == 1 # Ensure rollback on SQLAlchemyError

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/[connector_id]/edit/page.test.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/[connector_id]/edit/page.test.tsx
@@ -1,0 +1,302 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EditConnectorPage from './page'; // Adjust path if necessary
+import { useConnectorEditPage } from '@/hooks/useConnectorEditPage'; // Mock this hook
+import { SearchSourceConnector } from '@/hooks/useSearchSourceConnectors'; // For types
+import { toast } from 'sonner'; // Mock toast
+
+// Mock Next.js router and params
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+  useParams: () => ({
+    search_space_id: '1',
+    connector_id: '1', // Default for most tests, can be overridden in mock setup
+  }),
+}));
+
+// Mock the custom hook
+jest.mock('@/hooks/useConnectorEditPage');
+
+// Mock sonner
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+  },
+}));
+
+const mockDefaultForm = {
+  control: {} as any, // Basic mock for form control
+  handleSubmit: (fn: any) => (e: any) => { e.preventDefault(); fn(); },
+  setValue: jest.fn(),
+  getValues: jest.fn((key) => {
+    if (key === 'config') return mockUseConnectorEditPageValues.connector?.config || {};
+    return undefined;
+  }),
+  watch: jest.fn((key, defaultValue) => {
+    if (key === 'config.slack_membership_filter_type') {
+      return mockUseConnectorEditPageValues.connector?.config?.slack_membership_filter_type || defaultValue;
+    }
+    return defaultValue;
+  }),
+  formState: { errors: {} },
+} as any;
+
+let mockUseConnectorEditPageValues: any;
+
+const setupMockHook = (connectorData: Partial<SearchSourceConnector> | null) => {
+  const baseConnector: SearchSourceConnector = {
+    id: 1,
+    name: 'Test Connector',
+    connector_type: 'GENERIC',
+    is_indexable: true,
+    last_indexed_at: null,
+    config: {},
+    user_id: 'user1',
+    created_at: new Date().toISOString(),
+    ...connectorData,
+  };
+
+  mockUseConnectorEditPageValues = {
+    connectorsLoading: false,
+    connector: connectorData ? baseConnector : null,
+    isSaving: false,
+    editForm: { ...mockDefaultForm, getValues: jest.fn((key) => { // Ensure getValues is fresh
+        if (key === 'config') return baseConnector.config || {};
+        return undefined;
+    }), watch: jest.fn((key, defaultValue) => {
+        if (key === 'config.slack_membership_filter_type') {
+          return baseConnector.config?.slack_membership_filter_type || defaultValue;
+        }
+        return defaultValue;
+      }) 
+    },
+    patForm: { ...mockDefaultForm },
+    handleSaveChanges: jest.fn(),
+    // GitHub specific (not primary focus but part of hook)
+    editMode: false, setEditMode: jest.fn(), originalPat: '', currentSelectedRepos: [],
+    fetchedRepos: [], setFetchedRepos: jest.fn(), newSelectedRepos: [], setNewSelectedRepos: jest.fn(),
+    isFetchingRepos: false, handleFetchRepositories: jest.fn(), handleRepoSelectionChange: jest.fn(),
+    // Placeholder for Slack specific functions - these would be part of useSearchSourceConnectors usually
+    // and then exposed via useConnectorEditPage or called directly if page uses useSearchSourceConnectors
+    discoverSlackChannels: jest.fn(), 
+    triggerSlackReindex: jest.fn(),
+  };
+  (useConnectorEditPage as jest.Mock).mockReturnValue(mockUseConnectorEditPageValues);
+};
+
+
+describe('EditConnectorPage - Slack Channel Management', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Tab Visibility', () => {
+    test('shows "Channel Management" tab only for SLACK_CONNECTOR', () => {
+      setupMockHook({ connector_type: 'SLACK_CONNECTOR', config: { SLACK_BOT_TOKEN: 'token' } });
+      render(<EditConnectorPage />);
+      expect(screen.getByText('Configuration')).toBeInTheDocument();
+      expect(screen.getByText('Channel Management')).toBeInTheDocument();
+      expect(screen.getByText('Channel Management')).not.toBeDisabled();
+    });
+
+    test('disables "Channel Management" tab for non-Slack connectors', () => {
+      setupMockHook({ connector_type: 'GITHUB_CONNECTOR' });
+      render(<EditConnectorPage />);
+      expect(screen.getByText('Configuration')).toBeInTheDocument();
+      expect(screen.getByText('Channel Management')).toBeInTheDocument(); // Tab exists but is disabled
+      expect(screen.getByText('Channel Management')).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('Granular Channel Selection UI (SLACK_CONNECTOR)', () => {
+    const slackConnectorBase = {
+        connector_type: 'SLACK_CONNECTOR',
+        config: {
+            SLACK_BOT_TOKEN: 'valid-token',
+            slack_membership_filter_type: 'selected_member_channels', // Default to selected for these tests
+            slack_selected_channel_ids: [],
+        }
+    };
+
+    test('shows channel selection UI when type is "selected_member_channels"', async () => {
+      setupMockHook(slackConnectorBase);
+      render(<EditConnectorPage />);
+      await userEvent.click(screen.getByText('Channel Management')); // Navigate to tab
+      
+      expect(screen.getByText('Granular Channel Selection')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Discover & Select Channels/i })).toBeInTheDocument();
+    });
+
+    test('shows "All Channels Mode" message when type is "all_member_channels"', async () => {
+        setupMockHook({ 
+            ...slackConnectorBase, 
+            config: { ...slackConnectorBase.config, slack_membership_filter_type: 'all_member_channels' }
+        });
+        render(<EditConnectorPage />);
+        await userEvent.click(screen.getByText('Channel Management'));
+
+        expect(screen.getByText('All Channels Mode')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Discover & Select Channels/i })).not.toBeInTheDocument();
+    });
+    
+    test('discovering channels populates table and handles loading state', async () => {
+        setupMockHook(slackConnectorBase);
+        const mockDiscoveredChannels = [
+            { id: 'C1', name: 'General', is_private: false, is_member: true },
+            { id: 'C2', name: 'Random', is_private: false, is_member: true },
+        ];
+        // For this test, we assume handleDiscoverChannels is part of the page component itself, not the hook
+        // In a real scenario, this might be:
+        // mockUseConnectorEditPageValues.discoverSlackChannels.mockResolvedValue(mockDiscoveredChannels);
+        // For now, we'll check the button click and assume the mocked console.log from page implementation
+        
+        render(<EditConnectorPage />);
+        await userEvent.click(screen.getByText('Channel Management'));
+        
+        const discoverButton = screen.getByRole('button', { name: /Discover & Select Channels/i });
+        
+        // Simulate the page's handleDiscoverChannels
+        // This is a bit of a workaround as the function is internal to the component
+        // A better test would mock the API call if discoverSlackChannels was from the hook
+        // For now, we assert the button is there and would trigger the internal logic
+        expect(discoverButton).not.toBeDisabled();
+        await userEvent.click(discoverButton);
+
+        // Since handleDiscoverChannels is internal and uses setTimeout for mock, we need to wait
+        // This relies on the mock implementation within EditConnectorPage.tsx
+        expect(await screen.findByText('General')).toBeInTheDocument(); // Wait for table to populate
+        expect(screen.getByText('Random')).toBeInTheDocument();
+        expect(toast.success).toHaveBeenCalledWith("Discovered 2 channels where bot is a member.");
+    });
+
+    test('selecting channels and clicking "Update Channel Selection" calls setValue', async () => {
+        setupMockHook({
+            ...slackConnectorBase,
+            config: { ...slackConnectorBase.config, slack_selected_channel_ids: ['C1'] } // Pre-select one
+        });
+        render(<EditConnectorPage />);
+        await userEvent.click(screen.getByText('Channel Management'));
+
+        // First, discover channels to populate the table
+        const discoverButton = screen.getByRole('button', { name: /Discover & Select Channels/i });
+        await userEvent.click(discoverButton);
+        await screen.findByText('General'); // Wait for table
+
+        const checkboxGeneral = screen.getByRole('checkbox', { name: /select channel General/i }); // Assuming aria-label for checkbox
+        const checkboxRandom = screen.getByRole('checkbox', { name: /select channel Random/i });
+        
+        // Initial state from config
+        expect(checkboxGeneral).toBeChecked();
+        expect(checkboxRandom).not.toBeChecked();
+
+        // Deselect General, Select Random
+        await userEvent.click(checkboxGeneral);
+        await userEvent.click(checkboxRandom);
+
+        const updateButton = screen.getByRole('button', { name: /Update Channel Selection in Config/i });
+        await userEvent.click(updateButton);
+        
+        expect(mockUseConnectorEditPageValues.editForm.setValue).toHaveBeenCalledWith(
+            'config',
+            expect.objectContaining({ slack_selected_channel_ids: ['C2'] }), // C1 deselected, C2 selected
+            { shouldValidate: true, shouldDirty: true }
+        );
+        expect(toast.success).toHaveBeenCalledWith("Channel selection updated. Save changes to persist.");
+    });
+  });
+
+  describe('On-Demand Re-indexing UI (SLACK_CONNECTOR)', () => {
+    const slackConnectorWithChannels = {
+        connector_type: 'SLACK_CONNECTOR',
+        config: {
+            SLACK_BOT_TOKEN: 'valid-token',
+            slack_membership_filter_type: 'selected_member_channels',
+            slack_selected_channel_ids: ['C1_CONFIG', 'C2_CONFIG'], // Channels from config
+        }
+    };
+
+    test('displays channels for re-indexing and triggers reindex call', async () => {
+        setupMockHook(slackConnectorWithChannels);
+        // mockUseConnectorEditPageValues.triggerSlackReindex.mockResolvedValue({ message: "Re-index started" });
+
+        render(<EditConnectorPage />);
+        await userEvent.click(screen.getByText('Channel Management'));
+        
+        // Channels from config should be listed
+        expect(screen.getByText('Known ID: C1_CONFIG')).toBeInTheDocument();
+        expect(screen.getByText('Known ID: C2_CONFIG')).toBeInTheDocument();
+
+        const reindexCheckboxC1 = screen.getByRole('checkbox', { name: /select channel Known ID: C1_CONFIG/i });
+        await userEvent.click(reindexCheckboxC1); // Select C1 for re-index
+
+        const forceReindexCheckbox = screen.getByLabelText(/Full Re-index/i);
+        await userEvent.click(forceReindexCheckbox); // Enable force re-index
+
+        const startDateInput = screen.getByLabelText(/Re-index Start Date/i);
+        const latestDateInput = screen.getByLabelText(/Re-index Latest Date/i);
+        await userEvent.type(startDateInput, '2023-01-01');
+        await userEvent.type(latestDateInput, '2023-01-31');
+        
+        const reindexButton = screen.getByRole('button', { name: /Re-index Selected Channels/i });
+        expect(reindexButton).not.toBeDisabled();
+        await userEvent.click(reindexButton);
+
+        // Verify the internal handleTriggerReindex was called (via console.log or toast in mock)
+        // This relies on the mocked implementation within the page.
+        // A direct mock of an API call function from the hook would be better.
+        expect(toast.info).toHaveBeenCalledWith("Triggering re-indexing for selected channels...");
+        // We can't directly assert on `hookTriggerSlackReindex` as it's not directly called by the component
+        // but by the internal `handleTriggerReindex`.
+        // The console.log in the component's handleTriggerReindex would show:
+        // Re-indexing payload: { channel_ids: ['C1_CONFIG'], force_reindex_all_messages: true, reindex_start_date: '2023-01-01', reindex_latest_date: '2023-01-31' }
+        
+        // Wait for mocked async operation in handleTriggerReindex
+        await waitFor(() => {
+            expect(toast.success).toHaveBeenCalledWith("Re-indexing task scheduled successfully.");
+        });
+    });
+    
+    test('re-index button is disabled if no channels are selected', async () => {
+        setupMockHook(slackConnectorWithChannels);
+        render(<EditConnectorPage />);
+        await userEvent.click(screen.getByText('Channel Management'));
+        
+        const reindexButton = screen.getByRole('button', { name: /Re-index Selected Channels/i });
+        expect(reindexButton).toBeDisabled(); // Initially disabled
+
+        const reindexCheckboxC1 = screen.getByRole('checkbox', { name: /select channel Known ID: C1_CONFIG/i });
+        await userEvent.click(reindexCheckboxC1); // Select one
+        expect(reindexButton).not.toBeDisabled();
+
+        await userEvent.click(reindexCheckboxC1); // Deselect again
+        expect(reindexButton).toBeDisabled();
+    });
+
+    test('date inputs for re-indexing are shown only when "Full Re-index" is checked', async () => {
+        setupMockHook(slackConnectorWithChannels);
+        render(<EditConnectorPage />);
+        await userEvent.click(screen.getByText('Channel Management'));
+
+        expect(screen.queryByLabelText(/Re-index Start Date/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Re-index Latest Date/i)).not.toBeInTheDocument();
+
+        const forceReindexCheckbox = screen.getByLabelText(/Full Re-index/i);
+        await userEvent.click(forceReindexCheckbox);
+
+        expect(screen.getByLabelText(/Re-index Start Date/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/Re-index Latest Date/i)).toBeInTheDocument();
+
+        await userEvent.click(forceReindexCheckbox); // Uncheck
+
+        expect(screen.queryByLabelText(/Re-index Start Date/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Re-index Latest Date/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/surfsense_web/components/editConnector/EditSlackConnectorConfigForm.test.tsx
+++ b/surfsense_web/components/editConnector/EditSlackConnectorConfigForm.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'; // For more realistic interactions with Select
+import EditSlackConnectorConfigForm from './EditSlackConnectorConfigForm';
+import { SearchSourceConnector } from '@/hooks/useSearchSourceConnectors'; // Adjust path as needed
+
+// Mock UI components that are not part of the core logic being tested, if necessary
+// For ShadCN components, often direct interaction is fine, but sometimes they need setup.
+// For this test, we'll assume direct interaction works.
+// jest.mock("@/components/ui/input", () => (props: any) => <input {...props} data-testid={props.id || 'input-mock'} />);
+// jest.mock("@/components/ui/checkbox", () => (props: any) => <input type="checkbox" {...props} data-testid={props.id || 'checkbox-mock'} />);
+// jest.mock("@/components/ui/select", () => ({
+//   Select: (props: any) => <div data-testid={props.id || 'select-mock'}>{props.children}</div>,
+//   SelectTrigger: (props: any) => <button {...props}>{props.children}</button>,
+//   SelectValue: (props: any) => <div {...props}>{props.placeholder}</div>,
+//   SelectContent: (props: any) => <div {...props}>{props.children}</div>,
+//   SelectItem: (props: any) => <option value={props.value} {...props}>{props.children}</option>,
+// }));
+
+
+const initialMockConfig = {
+  SLACK_BOT_TOKEN: 'xoxb-initial-token',
+  slack_membership_filter_type: 'all_member_channels',
+  slack_selected_channel_ids: ['C123', 'C456'],
+  slack_initial_indexing_days: 30,
+  slack_initial_max_messages_per_channel: 1000,
+  slack_periodic_indexing_enabled: false,
+  slack_periodic_indexing_frequency: 'daily',
+  slack_max_messages_per_channel_periodic: 100,
+};
+
+const mockConnector: SearchSourceConnector = {
+  id: 1,
+  name: 'Slack Test Connector',
+  connector_type: 'SLACK_CONNECTOR',
+  is_indexable: true,
+  last_indexed_at: null,
+  config: { ...initialMockConfig },
+  user_id: 'user1',
+  created_at: new Date().toISOString(),
+};
+
+describe('EditSlackConnectorConfigForm', () => {
+  let mockOnConfigChange: jest.Mock;
+
+  beforeEach(() => {
+    mockOnConfigChange = jest.fn();
+  });
+
+  test('renders all form fields correctly with initial values', () => {
+    render(
+      <EditSlackConnectorConfigForm
+        connector={mockConnector}
+        onConfigChange={mockOnConfigChange}
+        disabled={false}
+      />
+    );
+
+    // Authentication
+    expect(screen.getByLabelText(/Slack Bot Token/i)).toHaveValue(initialMockConfig.SLACK_BOT_TOKEN);
+
+    // Initial Indexing Settings
+    expect(screen.getByText('Index All Channels Where Bot is Member')).toBeInTheDocument(); // For Select value display
+    expect(screen.getByText(/Channel selection is managed in the 'Channels' tab/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Initial Indexing Period \(days\)/i)).toHaveValue(initialMockConfig.slack_initial_indexing_days);
+    expect(screen.getByLabelText(/Max Messages Per Channel \(Initial Sync\)/i)).toHaveValue(initialMockConfig.slack_initial_max_messages_per_channel);
+    
+    // Periodic Indexing Settings
+    const periodicCheckbox = screen.getByLabelText(/Enable Periodic Indexing/i) as HTMLInputElement;
+    expect(periodicCheckbox.checked).toBe(initialMockConfig.slack_periodic_indexing_enabled);
+    
+    // Periodic fields should initially be hidden if checkbox is false
+    if (!initialMockConfig.slack_periodic_indexing_enabled) {
+      expect(screen.queryByLabelText(/Periodic Indexing Frequency/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/Max Messages Per Channel \(Periodic Sync\)/i)).not.toBeInTheDocument();
+    }
+  });
+
+  test('calls onConfigChange with updated config for SLACK_BOT_TOKEN', () => {
+    render(
+      <EditSlackConnectorConfigForm
+        connector={mockConnector}
+        onConfigChange={mockOnConfigChange}
+        disabled={false}
+      />
+    );
+    const tokenInput = screen.getByLabelText(/Slack Bot Token/i);
+    fireEvent.change(tokenInput, { target: { value: 'new-token' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ SLACK_BOT_TOKEN: 'new-token' })
+    );
+  });
+  
+  test('calls onConfigChange for slack_initial_indexing_days', () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={false} />);
+    const input = screen.getByLabelText(/Initial Indexing Period \(days\)/i);
+    fireEvent.change(input, { target: { value: '10' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_initial_indexing_days: 10 }));
+    
+    fireEvent.change(input, { target: { value: '-1' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_initial_indexing_days: -1 }));
+
+    fireEvent.change(input, { target: { value: '' } }); // Empty value
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_initial_indexing_days: null }));
+  });
+
+  test('calls onConfigChange for slack_initial_max_messages_per_channel', () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={false} />);
+    const input = screen.getByLabelText(/Max Messages Per Channel \(Initial Sync\)/i);
+    fireEvent.change(input, { target: { value: '500' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_initial_max_messages_per_channel: 500 }));
+  });
+
+  test('calls onConfigChange for slack_membership_filter_type', async () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={false} />);
+    
+    // For ShadCN Select, we need to click the trigger, then the item.
+    // `userEvent` is better for this, but `fireEvent` can also work.
+    const selectTrigger = screen.getByRole('combobox', { name: /Channel Indexing Behavior/i });
+    await userEvent.click(selectTrigger);
+    
+    // Assuming SelectItem roles are 'option' or similar, and they are now in the document
+    const option = await screen.findByText('Index Only Selected Channels'); // Wait for option to appear
+    await userEvent.click(option);
+
+    expect(mockOnConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ slack_membership_filter_type: 'selected_member_channels' })
+    );
+  });
+  
+  test('shows/hides periodic indexing fields and calls onConfigChange', async () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={false} />);
+    const periodicCheckbox = screen.getByLabelText(/Enable Periodic Indexing/i);
+
+    // Initially periodic fields are not visible (as per initialMockConfig)
+    expect(screen.queryByLabelText(/Periodic Indexing Frequency/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Max Messages Per Channel \(Periodic Sync\)/i)).not.toBeInTheDocument();
+
+    // Check the checkbox
+    fireEvent.click(periodicCheckbox);
+    expect(mockOnConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ slack_periodic_indexing_enabled: true })
+    );
+    
+    // Now the fields should be visible
+    const frequencySelect = await screen.findByLabelText(/Periodic Indexing Frequency/i); // Wait for it
+    const maxMessagesInput = screen.getByLabelText(/Max Messages Per Channel \(Periodic Sync\)/i);
+    expect(frequencySelect).toBeInTheDocument();
+    expect(maxMessagesInput).toBeInTheDocument();
+
+    // Change frequency
+    const freqSelectTrigger = screen.getByRole('combobox', { name: /Periodic Indexing Frequency/i });
+    await userEvent.click(freqSelectTrigger);
+    const weeklyOption = await screen.findByText('Weekly');
+    await userEvent.click(weeklyOption);
+    expect(mockOnConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ slack_periodic_indexing_frequency: 'weekly', slack_periodic_indexing_enabled: true })
+    );
+
+    // Change max messages periodic
+    fireEvent.change(maxMessagesInput, { target: { value: '75' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ slack_max_messages_per_channel_periodic: 75, slack_periodic_indexing_enabled: true })
+    );
+
+    // Uncheck the checkbox
+    fireEvent.click(periodicCheckbox);
+    expect(mockOnConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ slack_periodic_indexing_enabled: false })
+    );
+    
+    // Fields should be hidden again
+    expect(screen.queryByLabelText(/Periodic Indexing Frequency/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Max Messages Per Channel \(Periodic Sync\)/i)).not.toBeInTheDocument();
+  });
+
+  test('preserves other config values when one changes', () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={false} />);
+    const tokenInput = screen.getByLabelText(/Slack Bot Token/i);
+    fireEvent.change(tokenInput, { target: { value: 'new-xoxb-token' } });
+
+    expect(mockOnConfigChange).toHaveBeenCalledWith({
+      ...initialMockConfig, // All original values
+      SLACK_BOT_TOKEN: 'new-xoxb-token', // Only this one changed
+    });
+  });
+  
+  test('disables all form fields when disabled prop is true', () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={true} />);
+    
+    expect(screen.getByLabelText(/Slack Bot Token/i)).toBeDisabled();
+    expect(screen.getByRole('combobox', { name: /Channel Indexing Behavior/i })).toBeDisabled();
+    expect(screen.getByLabelText(/Initial Indexing Period \(days\)/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Max Messages Per Channel \(Initial Sync\)/i)).toBeDisabled();
+    expect(screen.getByLabelText(/Enable Periodic Indexing/i)).toBeDisabled();
+    
+    // If periodic indexing was enabled by default in mock, check those too
+    const connectorWithPeriodicEnabled = {
+        ...mockConnector,
+        config: { ...mockConnector.config, slack_periodic_indexing_enabled: true }
+    };
+    render(<EditSlackConnectorConfigForm connector={connectorWithPeriodicEnabled} onConfigChange={mockOnConfigChange} disabled={true} />);
+    expect(screen.getByRole('combobox', { name: /Periodic Indexing Frequency/i })).toBeDisabled();
+    expect(screen.getByLabelText(/Max Messages Per Channel \(Periodic Sync\)/i)).toBeDisabled();
+  });
+
+  test('handles empty string for number inputs correctly by converting to null', () => {
+    render(<EditSlackConnectorConfigForm connector={mockConnector} onConfigChange={mockOnConfigChange} disabled={false} />);
+    const initialDaysInput = screen.getByLabelText(/Initial Indexing Period \(days\)/i);
+    fireEvent.change(initialDaysInput, { target: { value: '' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_initial_indexing_days: null }));
+
+    const initialMaxMessagesInput = screen.getByLabelText(/Max Messages Per Channel \(Initial Sync\)/i);
+    fireEvent.change(initialMaxMessagesInput, { target: { value: '' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_initial_max_messages_per_channel: null }));
+
+    // Enable periodic to test that field
+    const periodicCheckbox = screen.getByLabelText(/Enable Periodic Indexing/i);
+    fireEvent.click(periodicCheckbox); // Enable
+    
+    const periodicMaxMessagesInput = screen.getByLabelText(/Max Messages Per Channel \(Periodic Sync\)/i);
+    fireEvent.change(periodicMaxMessagesInput, { target: { value: '' } });
+    expect(mockOnConfigChange).toHaveBeenCalledWith(expect.objectContaining({ slack_max_messages_per_channel_periodic: null }));
+  });
+
+});

--- a/surfsense_web/hooks/useSearchSourceConnectors.test.ts
+++ b/surfsense_web/hooks/useSearchSourceConnectors.test.ts
@@ -1,0 +1,247 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSearchSourceConnectors, SlackChannelInfo } from './useSearchSourceConnectors'; // Adjust path as needed
+
+// Helper to create a mock response for fetch
+const mockFetchResponse = (data: any, ok: boolean = true, status: number = 200) => {
+  return Promise.resolve({
+    ok,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)), // For error messages
+  } as Response);
+};
+
+const mockFetchResponseNoContent = (ok: boolean = true, status: number = 202) => {
+    return Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.reject(new Error("No JSON content")), // Should not be called for 202/204
+      text: () => Promise.resolve(""), 
+    } as Response);
+  };
+
+describe('useSearchSourceConnectors Hook - Slack Operations', () => {
+  let mockFetch: jest.SpyInstance;
+  let mockLocalStorageGetItem: jest.SpyInstance;
+
+  const mockApiUrl = 'http://localhost:8000/api/v1'; // Example, ensure it matches env
+  process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL = mockApiUrl;
+
+
+  beforeEach(() => {
+    // Spy on global fetch
+    mockFetch = jest.spyOn(window, 'fetch');
+    // Mock localStorage
+    mockLocalStorageGetItem = jest.spyOn(Storage.prototype, 'getItem');
+    mockLocalStorageGetItem.mockReturnValue('test-token'); // Default to having a token
+  });
+
+  afterEach(() => {
+    mockFetch.mockRestore();
+    mockLocalStorageGetItem.mockRestore();
+  });
+
+  describe('discoverSlackChannels', () => {
+    test('successful API call returns channels and calls fetch correctly', async () => {
+      const mockChannelsData: { channels: SlackChannelInfo[] } = {
+        channels: [
+          { id: 'C1', name: 'General', is_private: false, is_member: true },
+          { id: 'C2', name: 'Random', is_private: true, is_member: true },
+        ],
+      };
+      mockFetch.mockReturnValueOnce(mockFetchResponse(mockChannelsData));
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      // Wait for initial connectors fetch to complete if any (though not directly tested here)
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+
+      let discoveredChannels: SlackChannelInfo[] = [];
+      await act(async () => {
+        discoveredChannels = await result.current.discoverSlackChannels(1);
+      });
+      
+      expect(discoveredChannels).toEqual(mockChannelsData.channels);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${mockApiUrl}/slack/1/discover-channels`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer test-token',
+            'Content-Type': 'application/json',
+          }),
+        })
+      );
+    });
+
+    test('API error throws an error', async () => {
+      mockFetch.mockReturnValueOnce(mockFetchResponse({ detail: 'API Error' }, false, 500));
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(result.current.discoverSlackChannels(1)).rejects.toThrow(
+        /API request failed: Internal Server Error - {"detail":"API Error"}/
+      );
+    });
+
+    test('no token throws an error', async () => {
+      mockLocalStorageGetItem.mockReturnValueOnce(null); // No token
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      // Initial fetch will fail here, which is fine for this test's focus
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+
+      await expect(result.current.discoverSlackChannels(1)).rejects.toThrow(
+        'No authentication token found'
+      );
+      expect(mockFetch).not.toHaveBeenCalled(); // fetchWithAuth should prevent call
+    });
+  });
+
+  describe('reindexSlackChannels', () => {
+    test('successful API call (basic) calls fetch correctly', async () => {
+      mockFetch.mockReturnValueOnce(mockFetchResponseNoContent(true, 202)); // 202 Accepted
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.reindexSlackChannels(1, ['C1', 'C2']);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${mockApiUrl}/slack/1/reindex-channels`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer test-token',
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({
+            channel_ids: ['C1', 'C2'],
+            force_reindex_all_messages: undefined, // Explicitly undefined if not passed
+            reindex_start_date: null, // Defaulted to null if not passed
+            reindex_latest_date: null, // Defaulted to null if not passed
+          }),
+        })
+      );
+    });
+
+    test('successful API call with all optional parameters', async () => {
+      mockFetch.mockReturnValueOnce(mockFetchResponseNoContent(true, 202));
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      
+      await act(async () => {
+        await result.current.reindexSlackChannels(
+          1,
+          ['C1'],
+          true,
+          '2023-01-01',
+          '2023-01-31'
+        );
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${mockApiUrl}/slack/1/reindex-channels`,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            channel_ids: ['C1'],
+            force_reindex_all_messages: true,
+            reindex_start_date: '2023-01-01',
+            reindex_latest_date: '2023-01-31',
+          }),
+        })
+      );
+    });
+    
+    test('handles empty date strings by passing null', async () => {
+        mockFetch.mockReturnValueOnce(mockFetchResponseNoContent(true, 202));
+  
+        const { result } = renderHook(() => useSearchSourceConnectors());
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        
+        await act(async () => {
+          await result.current.reindexSlackChannels(
+            1,
+            ['C1'],
+            true,
+            '', // Empty start date
+            ''  // Empty latest date
+          );
+        });
+  
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${mockApiUrl}/slack/1/reindex-channels`,
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({
+              channel_ids: ['C1'],
+              force_reindex_all_messages: true,
+              reindex_start_date: null, // Should be null
+              reindex_latest_date: null, // Should be null
+            }),
+          })
+        );
+      });
+
+    test('API error throws an error during reindex', async () => {
+      mockFetch.mockReturnValueOnce(mockFetchResponse({ detail: 'Reindex Failed' }, false, 400));
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(result.current.reindexSlackChannels(1, ['C1'])).rejects.toThrow(
+        /API request failed: Bad Request - {"detail":"Reindex Failed"}/
+      );
+    });
+
+    test('no token throws an error during reindex', async () => {
+      mockLocalStorageGetItem.mockReturnValueOnce(null); // No token
+
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(result.current.reindexSlackChannels(1, ['C1'])).rejects.toThrow(
+        'No authentication token found'
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+  
+  // Basic test for fetchWithAuth behavior (implicitly tested by others, but can be explicit)
+  describe('fetchWithAuth internal behavior', () => {
+    test('fetchWithAuth throws if no token', async () => {
+      mockLocalStorageGetItem.mockReturnValueOnce(null);
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      // The hook itself might make initial calls, let them pass/fail
+      await waitFor(() => expect(result.current.isLoading).toBe(false)); 
+      
+      // Attempting any operation that uses fetchWithAuth internally should fail early
+      // For example, discoverSlackChannels
+      await expect(result.current.discoverSlackChannels(1)).rejects.toThrow('No authentication token found');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('fetchWithAuth includes Authorization header', async () => {
+      mockFetch.mockReturnValueOnce(mockFetchResponse({ channels: [] })); // For discoverSlackChannels
+      const { result } = renderHook(() => useSearchSourceConnectors());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.discoverSlackChannels(1);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
…implemented Slack connector features. This includes tests for backend logic (SlackHistory, indexing tasks, API routes) and frontend components and hooks.

Backend Tests (`surfsense_backend`):
- `test_slack_history.py`:
    - Tests for `SlackHistory` class methods including `get_all_channels`, `get_conversation_history`, timestamp conversions, and message formatting. Covers various API response scenarios, pagination, and error handling.
- `test_connectors_indexing_tasks.py`:
    - Unit tests for `index_slack_messages` task.
    - Scenarios include initial indexing, periodic indexing, on-demand re-indexing (targeted channels, force re-index, custom dates), channel filtering, and error handling.
    - Mocks `SlackHistory` and database interactions.
- `test_search_source_connectors_routes.py`:
    - Tests for `/slack/{connector_id}/discover-channels` endpoint.
    - Tests for `/slack/{connector_id}/reindex-channels` endpoint, verifying parameter passing to the background task.
    - Tests for the main `/search-source-connectors/{connector_id}/index` endpoint for Slack connectors, ensuring the `force_full_reindex` flag is handled.

Frontend Tests (`surfsense_web`):
- `components/editConnector/EditSlackConnectorConfigForm.test.tsx`:
    - Tests rendering of all Slack configuration fields.
    - Verifies `onConfigChange` callback functionality.
    - Tests conditional rendering of periodic indexing settings.
    - Checks disabled state of the form.
- `app/dashboard/[search_space_id]/connectors/[connector_id]/edit/page.test.tsx`:
    - Tests for the "Channel Management" tab specific to Slack connectors.
    - Verifies UI for discovering channels (mocking API calls).
    - Tests selection of channels and updating the connector configuration.
    - Tests UI for triggering on-demand re-indexing with various options.
- `hooks/useSearchSourceConnectors.test.ts`:
    - Unit tests for the `discoverSlackChannels` function, mocking `fetch`.
    - Unit tests for the `reindexSlackChannels` function, mocking `fetch` and verifying correct request body construction.
    - Includes testing of the `fetchWithAuth` helper function.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #

## Changes Overview
<!-- List the primary changes/improvements made in this PR -->
- 

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement (non-breaking change which enhances performance)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
<!-- Describe the tests that have been run to verify your changes -->
- [ ] I have tested these changes locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires documentation updates
- [ ] I have updated the documentation accordingly
- [ ] My change requires dependency updates
- [ ] I have updated the dependencies accordingly
- [ ] My code builds clean without any errors or warnings
- [ ] All new and existing tests passed 