### PR TITLE
fix: Correct syntax error in EditSlackConnectorConfigForm

### DIFF
--- a/surfsense_web/components/editConnector/EditSlackConnectorConfigForm.tsx
+++ b/surfsense_web/components/editConnector/EditSlackConnectorConfigForm.tsx
@@ -198,4 +198,3 @@ const EditSlackConnectorConfigForm: React.FC<EditSlackConnectorConfigFormProps> 
 };
 
 export default EditSlackConnectorConfigForm;
-</>


### PR DESCRIPTION
Removes an extraneous closing JSX fragment tag (`</>`) at the end of the file `surfsense_web/components/editConnector/EditSlackConnectorConfigForm.tsx` that was causing a compilation error.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #

## Changes Overview
<!-- List the primary changes/improvements made in this PR -->
- 

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement (non-breaking change which enhances performance)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
<!-- Describe the tests that have been run to verify your changes -->
- [ ] I have tested these changes locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires documentation updates
- [ ] I have updated the documentation accordingly
- [ ] My change requires dependency updates
- [ ] I have updated the dependencies accordingly
- [ ] My code builds clean without any errors or warnings
- [ ] All new and existing tests passed 